### PR TITLE
updated hover transition

### DIFF
--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -68,10 +68,16 @@
       transition: all .2s ease-in-out;
     }
 
+    &--svg {
+      transition: all 0.2s ease-in-out;
+      fill: #350716; // Default color (e.g., pink)
+    }
+
     // dribbble svg hover section
     &--svg:hover {
       cursor: pointer;
       @include medium-920 {
+        fill: #f92e0a;
         opacity: 0.8;
       }
     }

--- a/scss/_header.scss
+++ b/scss/_header.scss
@@ -68,17 +68,11 @@
       transition: all .2s ease-in-out;
     }
 
-    &--svg {
-      transition: all 0.2s ease-in-out;
-      fill: #350716; // Default color (e.g., pink)
-    }
-
     // dribbble svg hover section
     &--svg:hover {
       cursor: pointer;
       @include medium-920 {
-        fill: #f92e0a;
-        opacity: 0.8;
+        opacity: 0.6;
       }
     }
 
@@ -690,3 +684,4 @@
     }
   }
 }
+


### PR DESCRIPTION
changed the hover color and opacity.

 // Dribbble svg 
    &--svg{
      transition: all .2s ease-in-out;
    }
 &--svg {
      transition: all 0.2s ease-in-out;
      fill: #350716; // Default color (e.g., pink)
    }

    // dribbble svg hover section
    &--svg:hover {
      cursor: pointer;
      @include medium-920 {
        fill: #f92e0a;
        opacity: 0.8;
      }
    }